### PR TITLE
lab1: add minesweeper layout

### DIFF
--- a/KovtunOleksandra/index.html
+++ b/KovtunOleksandra/index.html
@@ -15,7 +15,7 @@
         <!-- Хедер гри -->
         <header class="game-header">
 
-            <div class="game-info">
+            <div class="game-info" role="status" aria-live="polite" aria-label="Статус гри">
 
                 <div class="counter" aria-label="Кількість прапорців">
                     <span class="counter-icon">🚩</span>
@@ -48,7 +48,7 @@
 
                 <!-- 1 ряд -->
                 <div class="cell"></div>
-                <div class="cell flag">🚩</div>
+                <div class="cell flag flagged-mine">🚩</div>
                 <div class="cell"></div>
                 <div class="cell"></div>
 
@@ -68,7 +68,7 @@
                 <div class="cell"></div>
                 <div class="cell open num-1">1</div>
                 <div class="cell open num-2">2</div>
-                <div class="cell flag">🚩</div>
+                <div class="cell flag flagged-safe">❌</div>
 
             </section>
         </main>

--- a/KovtunOleksandra/index.html
+++ b/KovtunOleksandra/index.html
@@ -1,0 +1,79 @@
+
+<!DOCTYPE html>
+<html lang="uk">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Minesweeper</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+
+<body>
+
+    <div class="game-container">
+
+        <!-- Хедер гри -->
+        <header class="game-header">
+
+            <div class="game-info">
+
+                <div class="counter" aria-label="Кількість прапорців">
+                    <span class="counter-icon">🚩</span>
+                    <span id="flag-count">010</span>
+                </div>
+
+                <div class="counter" aria-label="Час гри">
+                    <span class="counter-icon">⏱️</span>
+                    <span id="timer">000</span>
+                </div>
+
+            </div>
+
+            <button
+                class="reset-btn"
+                type="button"
+                aria-label="Почати нову гру"
+            >
+                😃
+            </button>
+
+        </header>
+
+        <!-- Ігрове поле -->
+        <main>
+            <section
+                class="game-board"
+                aria-label="Ігрове поле Minesweeper"
+            >
+
+                <!-- 1 ряд -->
+                <div class="cell"></div>
+                <div class="cell flag">🚩</div>
+                <div class="cell"></div>
+                <div class="cell"></div>
+
+                <!-- 2 ряд -->
+                <div class="cell open num-1">1</div>
+                <div class="cell open num-2">2</div>
+                <div class="cell open num-1">1</div>
+                <div class="cell open empty"></div>
+
+                <!-- 3 ряд -->
+                <div class="cell open empty"></div>
+                <div class="cell open num-1">1</div>
+                <div class="cell open mine clicked">💣</div>
+                <div class="cell open mine">💣</div>
+
+                <!-- 4 ряд -->
+                <div class="cell"></div>
+                <div class="cell open num-1">1</div>
+                <div class="cell open num-2">2</div>
+                <div class="cell flag">🚩</div>
+
+            </section>
+        </main>
+
+    </div>
+
+</body>
+</html>

--- a/KovtunOleksandra/styles.css
+++ b/KovtunOleksandra/styles.css
@@ -276,6 +276,7 @@ body {
    ========================= */
 
 @media (width <= 400px) {
+
     body {
         padding: 14px;
     }
@@ -305,4 +306,5 @@ body {
         gap: 4px;
         padding: 7px;
     }
+
 }

--- a/KovtunOleksandra/styles.css
+++ b/KovtunOleksandra/styles.css
@@ -13,19 +13,23 @@
     --background: #111022;
     --container: #1b1833;
     --header: #24203f;
+
     /* Ігрове поле */
     --board: #2b2748;
     --cell-closed: #353052;
     --cell-hover: #403a63;
     --cell-open: #25223f;
+
     /* Текст */
     --text: #f4f1ff;
     --text-secondary: #aaa4c7;
+
     /* Кольори цифр */
     --blue: #6ea8ff;
     --green: #69d69b;
     --red: #ff6b7a;
     --orange: #ffb86c;
+
     /* Міна */
     --mine-red: #b8324a;
 }
@@ -275,23 +279,28 @@ body {
     body {
         padding: 14px;
     }
+
     .game-container {
         padding: 14px;
         border-radius: 20px;
     }
+
     .game-header {
         padding: 8px;
     }
+
     .counter {
         min-width: 68px;
         padding: 7px 8px;
         font-size: 0.82rem;
     }
+
     .reset-btn {
         width: 40px;
         height: 40px;
         font-size: 1.35rem;
     }
+
     .game-board {
         gap: 4px;
         padding: 7px;

--- a/KovtunOleksandra/styles.css
+++ b/KovtunOleksandra/styles.css
@@ -32,6 +32,10 @@
 
     /* Міна */
     --mine-red: #b8324a;
+
+    /* Налаштування логіки */
+    --board-columns: 4;
+    --mine-shake-duration: 0.3s;
 }
 
 /* =========================
@@ -146,7 +150,7 @@ body {
 
 .game-board {
     display: grid;
-    grid-template-columns: repeat(4, 1fr);
+    grid-template-columns: repeat(var(--board-columns), 1fr);
     gap: 5px;
     padding: 8px;
     background: var(--board);
@@ -228,9 +232,17 @@ body {
    ========================= */
 
 .cell.flag {
-    background: #3a345c;
     font-size: 1.3rem;
     box-shadow: inset 0 2px 0 rgb(255 255 255 / 7%), 0 3px 5px rgb(0 0 0 / 25%);
+}
+
+.cell.flag.flagged-mine {
+    background: #3a345c;
+}
+
+.cell.flag.flagged-safe {
+    background: #4a2a35;
+    opacity: 0.8;
 }
 
 /* =========================
@@ -246,7 +258,7 @@ body {
 .cell.mine.clicked {
     background: var(--mine-red);
     box-shadow: inset 0 3px 6px rgb(70 0 15 / 45%);
-    animation: shake 0.3s ease-in-out;
+    animation: shake var(--mine-shake-duration) ease-in-out;
 }
 
 /* =========================

--- a/KovtunOleksandra/styles.css
+++ b/KovtunOleksandra/styles.css
@@ -1,0 +1,421 @@
+
+/* =========================
+   Базові налаштування
+   ========================= */
+
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+:root {
+    /* Основні кольори */
+    --background: #111022;
+    --container: #1b1833;
+    --header: #24203f;
+
+    /* Ігрове поле */
+    --board: #2b2748;
+    --cell-closed: #353052;
+    --cell-hover: #403a63;
+    --cell-open: #25223f;
+
+    /* Текст */
+    --text: #f4f1ff;
+    --text-secondary: #aaa4c7;
+
+    /* Кольори цифр */
+    --blue: #6ea8ff;
+    --green: #69d69b;
+    --red: #ff6b7a;
+    --orange: #ffb86c;
+
+    /* Міна */
+    --mine-red: #b8324a;
+}
+
+
+/* =========================
+   Сторінка
+   ========================= */
+
+body {
+    min-height: 100vh;
+
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    padding: 24px;
+
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        sans-serif;
+
+    color: var(--text);
+
+    background:
+        radial-gradient(
+            circle at top,
+            #28234b 0%,
+            #17152d 40%,
+            var(--background) 75%
+        );
+}
+
+
+/* =========================
+   Основний контейнер
+   ========================= */
+
+.game-container {
+    width: 100%;
+    max-width: 340px;
+
+    padding: 20px;
+
+    background: var(--container);
+
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    border-radius: 24px;
+
+    box-shadow:
+        0 25px 60px rgba(0, 0, 0, 0.45),
+        0 0 30px rgba(88, 70, 160, 0.12);
+}
+
+
+/* =========================
+   Хедер
+   ========================= */
+
+.game-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+
+    margin-bottom: 18px;
+    padding: 10px;
+
+    background: var(--header);
+
+    border: 1px solid rgba(255, 255, 255, 0.05);
+    border-radius: 16px;
+
+    box-shadow:
+        inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+
+/* Інформація про гру */
+
+.game-info {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+
+/* Лічильники */
+
+.counter {
+    min-width: 78px;
+
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+
+    padding: 8px 10px;
+
+    background: #18152f;
+
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    border-radius: 10px;
+
+    color: var(--text);
+
+    font-family: "SFMono-Regular", Consolas, monospace;
+    font-size: 0.9rem;
+    font-weight: 700;
+
+    box-shadow:
+        inset 0 1px 2px rgba(0, 0, 0, 0.25);
+}
+
+.counter-icon {
+    font-family: sans-serif;
+    font-size: 1rem;
+}
+
+
+/* =========================
+   Кнопка нової гри
+   ========================= */
+
+.reset-btn {
+    width: 44px;
+    height: 44px;
+
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    border-radius: 12px;
+
+    background: #302a50;
+
+    font-size: 1.5rem;
+
+    cursor: pointer;
+    user-select: none;
+
+    box-shadow:
+        0 4px 10px rgba(0, 0, 0, 0.25);
+
+    transition:
+        transform 0.15s ease,
+        background-color 0.15s ease,
+        box-shadow 0.15s ease;
+}
+
+.reset-btn:hover {
+    background: #3b3461;
+
+    box-shadow:
+        0 5px 14px rgba(0, 0, 0, 0.3);
+}
+
+.reset-btn:active {
+    transform: scale(0.9);
+}
+
+
+/* =========================
+   Ігрове поле
+   ========================= */
+
+.game-board {
+    display: grid;
+
+    grid-template-columns: repeat(4, 1fr);
+    gap: 5px;
+
+    padding: 8px;
+
+    background: var(--board);
+
+    border: 1px solid rgba(255, 255, 255, 0.05);
+    border-radius: 14px;
+
+    box-shadow:
+        inset 0 2px 6px rgba(0, 0, 0, 0.3);
+}
+
+
+/* =========================
+   Клітинка
+   ========================= */
+
+.cell {
+    aspect-ratio: 1 / 1;
+
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    border-radius: 8px;
+
+    background: var(--cell-closed);
+
+    color: var(--text);
+
+    font-size: clamp(1.1rem, 5vw, 1.45rem);
+    font-weight: 800;
+
+    cursor: pointer;
+    user-select: none;
+
+    box-shadow:
+        inset 0 2px 0 rgba(255, 255, 255, 0.08),
+        0 3px 5px rgba(0, 0, 0, 0.25);
+
+    transition:
+        background-color 0.15s ease,
+        transform 0.1s ease;
+}
+
+
+/* Закрита клітинка при наведенні */
+
+.cell:not(.open):hover {
+    background: var(--cell-hover);
+}
+
+
+/* Натискання на закриту клітинку */
+
+.cell:not(.open):active {
+    transform: scale(0.93);
+
+    box-shadow:
+        inset 0 2px 5px rgba(0, 0, 0, 0.3);
+}
+
+
+/* =========================
+   Відкрита клітинка
+   ========================= */
+
+.cell.open {
+    background: var(--cell-open);
+
+    cursor: default;
+
+    box-shadow:
+        inset 0 2px 4px rgba(0, 0, 0, 0.25);
+}
+
+
+/* Порожня клітинка */
+
+.cell.empty {
+    color: transparent;
+}
+
+
+/* =========================
+   Цифри
+   ========================= */
+
+.num-1 {
+    color: var(--blue);
+
+    text-shadow:
+        0 0 8px rgba(110, 168, 255, 0.2);
+}
+
+.num-2 {
+    color: var(--green);
+
+    text-shadow:
+        0 0 8px rgba(105, 214, 155, 0.2);
+}
+
+.num-3 {
+    color: var(--red);
+
+    text-shadow:
+        0 0 8px rgba(255, 107, 122, 0.2);
+}
+
+
+/* =========================
+   Прапорець
+   ========================= */
+
+.cell.flag {
+    background: #3a345c;
+
+    font-size: 1.3rem;
+
+    box-shadow:
+        inset 0 2px 0 rgba(255, 255, 255, 0.07),
+        0 3px 5px rgba(0, 0, 0, 0.25);
+}
+
+
+/* =========================
+   Міни
+   ========================= */
+
+.cell.mine {
+    font-size: 1.3rem;
+}
+
+
+/* Міна, на яку натиснув користувач */
+
+.cell.mine.clicked {
+    background: var(--mine-red);
+
+    box-shadow:
+        inset 0 3px 6px rgba(70, 0, 15, 0.45);
+
+    animation: shake 0.3s ease-in-out;
+}
+
+
+/* =========================
+   Анімація вибуху
+   ========================= */
+
+@keyframes shake {
+    0% {
+        transform: translateX(0);
+    }
+
+    25% {
+        transform: translateX(-3px);
+    }
+
+    50% {
+        transform: translateX(3px);
+    }
+
+    75% {
+        transform: translateX(-3px);
+    }
+
+    100% {
+        transform: translateX(0);
+    }
+}
+
+
+/* =========================
+   Адаптивність
+   ========================= */
+
+@media (max-width: 400px) {
+
+    body {
+        padding: 14px;
+    }
+
+    .game-container {
+        padding: 14px;
+        border-radius: 20px;
+    }
+
+    .game-header {
+        padding: 8px;
+    }
+
+    .counter {
+        min-width: 68px;
+
+        padding: 7px 8px;
+
+        font-size: 0.82rem;
+    }
+
+    .reset-btn {
+        width: 40px;
+        height: 40px;
+
+        font-size: 1.35rem;
+    }
+
+    .game-board {
+        gap: 4px;
+        padding: 7px;
+    }
+}

--- a/KovtunOleksandra/styles.css
+++ b/KovtunOleksandra/styles.css
@@ -257,15 +257,19 @@ body {
     0% {
         transform: translateX(0);
     }
+
     25% {
         transform: translateX(-3px);
     }
+
     50% {
         transform: translateX(3px);
     }
+
     75% {
         transform: translateX(-3px);
     }
+
     100% {
         transform: translateX(0);
     }
@@ -276,7 +280,6 @@ body {
    ========================= */
 
 @media (width <= 400px) {
-
     body {
         padding: 14px;
     }

--- a/KovtunOleksandra/styles.css
+++ b/KovtunOleksandra/styles.css
@@ -1,4 +1,3 @@
-
 /* =========================
    Базові налаштування
    ========================= */
@@ -14,27 +13,22 @@
     --background: #111022;
     --container: #1b1833;
     --header: #24203f;
-
     /* Ігрове поле */
     --board: #2b2748;
     --cell-closed: #353052;
     --cell-hover: #403a63;
     --cell-open: #25223f;
-
     /* Текст */
     --text: #f4f1ff;
     --text-secondary: #aaa4c7;
-
     /* Кольори цифр */
     --blue: #6ea8ff;
     --green: #69d69b;
     --red: #ff6b7a;
     --orange: #ffb86c;
-
     /* Міна */
     --mine-red: #b8324a;
 }
-
 
 /* =========================
    Сторінка
@@ -42,33 +36,14 @@
 
 body {
     min-height: 100vh;
-
     display: flex;
     justify-content: center;
     align-items: center;
-
     padding: 24px;
-
-    font-family:
-        -apple-system,
-        BlinkMacSystemFont,
-        "Segoe UI",
-        Roboto,
-        Helvetica,
-        Arial,
-        sans-serif;
-
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
     color: var(--text);
-
-    background:
-        radial-gradient(
-            circle at top,
-            #28234b 0%,
-            #17152d 40%,
-            var(--background) 75%
-        );
+    background: radial-gradient(circle at top, #28234b 0%, #17152d 40%, var(--background) 75%);
 }
-
 
 /* =========================
    Основний контейнер
@@ -77,19 +52,12 @@ body {
 .game-container {
     width: 100%;
     max-width: 340px;
-
     padding: 20px;
-
     background: var(--container);
-
-    border: 1px solid rgba(255, 255, 255, 0.06);
+    border: 1px solid rgb(255 255 255 / 6%);
     border-radius: 24px;
-
-    box-shadow:
-        0 25px 60px rgba(0, 0, 0, 0.45),
-        0 0 30px rgba(88, 70, 160, 0.12);
+    box-shadow: 0 25px 60px rgb(0 0 0 / 45%), 0 0 30px rgb(88 70 160 / 12%);
 }
-
 
 /* =========================
    Хедер
@@ -99,19 +67,13 @@ body {
     display: flex;
     align-items: center;
     justify-content: space-between;
-
     margin-bottom: 18px;
     padding: 10px;
-
     background: var(--header);
-
-    border: 1px solid rgba(255, 255, 255, 0.05);
+    border: 1px solid rgb(255 255 255 / 5%);
     border-radius: 16px;
-
-    box-shadow:
-        inset 0 1px 0 rgba(255, 255, 255, 0.04);
+    box-shadow: inset 0 1px 0 rgb(255 255 255 / 4%);
 }
-
 
 /* Інформація про гру */
 
@@ -121,39 +83,29 @@ body {
     gap: 8px;
 }
 
-
 /* Лічильники */
 
 .counter {
     min-width: 78px;
-
     display: flex;
     align-items: center;
     justify-content: center;
     gap: 6px;
-
     padding: 8px 10px;
-
     background: #18152f;
-
-    border: 1px solid rgba(255, 255, 255, 0.06);
+    border: 1px solid rgb(255 255 255 / 6%);
     border-radius: 10px;
-
     color: var(--text);
-
-    font-family: "SFMono-Regular", Consolas, monospace;
+    font-family: SFMono-Regular, Consolas, monospace;
     font-size: 0.9rem;
     font-weight: 700;
-
-    box-shadow:
-        inset 0 1px 2px rgba(0, 0, 0, 0.25);
+    box-shadow: inset 0 1px 2px rgb(0 0 0 / 25%);
 }
 
 .counter-icon {
     font-family: sans-serif;
     font-size: 1rem;
 }
-
 
 /* =========================
    Кнопка нової гри
@@ -162,41 +114,27 @@ body {
 .reset-btn {
     width: 44px;
     height: 44px;
-
     display: flex;
     align-items: center;
     justify-content: center;
-
-    border: 1px solid rgba(255, 255, 255, 0.06);
+    border: 1px solid rgb(255 255 255 / 6%);
     border-radius: 12px;
-
     background: #302a50;
-
     font-size: 1.5rem;
-
     cursor: pointer;
     user-select: none;
-
-    box-shadow:
-        0 4px 10px rgba(0, 0, 0, 0.25);
-
-    transition:
-        transform 0.15s ease,
-        background-color 0.15s ease,
-        box-shadow 0.15s ease;
+    box-shadow: 0 4px 10px rgb(0 0 0 / 25%);
+    transition: transform 0.15s ease, background-color 0.15s ease, box-shadow 0.15s ease;
 }
 
 .reset-btn:hover {
     background: #3b3461;
-
-    box-shadow:
-        0 5px 14px rgba(0, 0, 0, 0.3);
+    box-shadow: 0 5px 14px rgb(0 0 0 / 30%);
 }
 
 .reset-btn:active {
     transform: scale(0.9);
 }
-
 
 /* =========================
    Ігрове поле
@@ -204,21 +142,14 @@ body {
 
 .game-board {
     display: grid;
-
     grid-template-columns: repeat(4, 1fr);
     gap: 5px;
-
     padding: 8px;
-
     background: var(--board);
-
-    border: 1px solid rgba(255, 255, 255, 0.05);
+    border: 1px solid rgb(255 255 255 / 5%);
     border-radius: 14px;
-
-    box-shadow:
-        inset 0 2px 6px rgba(0, 0, 0, 0.3);
+    box-shadow: inset 0 2px 6px rgb(0 0 0 / 30%);
 }
-
 
 /* =========================
    Клітинка
@@ -226,32 +157,19 @@ body {
 
 .cell {
     aspect-ratio: 1 / 1;
-
     display: flex;
     align-items: center;
     justify-content: center;
-
     border-radius: 8px;
-
     background: var(--cell-closed);
-
     color: var(--text);
-
     font-size: clamp(1.1rem, 5vw, 1.45rem);
     font-weight: 800;
-
     cursor: pointer;
     user-select: none;
-
-    box-shadow:
-        inset 0 2px 0 rgba(255, 255, 255, 0.08),
-        0 3px 5px rgba(0, 0, 0, 0.25);
-
-    transition:
-        background-color 0.15s ease,
-        transform 0.1s ease;
+    box-shadow: inset 0 2px 0 rgb(255 255 255 / 8%), 0 3px 5px rgb(0 0 0 / 25%);
+    transition: background-color 0.15s ease, transform 0.1s ease;
 }
-
 
 /* Закрита клітинка при наведенні */
 
@@ -259,16 +177,12 @@ body {
     background: var(--cell-hover);
 }
 
-
 /* Натискання на закриту клітинку */
 
 .cell:not(.open):active {
     transform: scale(0.93);
-
-    box-shadow:
-        inset 0 2px 5px rgba(0, 0, 0, 0.3);
+    box-shadow: inset 0 2px 5px rgb(0 0 0 / 30%);
 }
-
 
 /* =========================
    Відкрита клітинка
@@ -276,13 +190,9 @@ body {
 
 .cell.open {
     background: var(--cell-open);
-
     cursor: default;
-
-    box-shadow:
-        inset 0 2px 4px rgba(0, 0, 0, 0.25);
+    box-shadow: inset 0 2px 4px rgb(0 0 0 / 25%);
 }
-
 
 /* Порожня клітинка */
 
@@ -290,32 +200,24 @@ body {
     color: transparent;
 }
 
-
 /* =========================
    Цифри
    ========================= */
 
 .num-1 {
     color: var(--blue);
-
-    text-shadow:
-        0 0 8px rgba(110, 168, 255, 0.2);
+    text-shadow: 0 0 8px rgb(110 168 255 / 20%);
 }
 
 .num-2 {
     color: var(--green);
-
-    text-shadow:
-        0 0 8px rgba(105, 214, 155, 0.2);
+    text-shadow: 0 0 8px rgb(105 214 155 / 20%);
 }
 
 .num-3 {
     color: var(--red);
-
-    text-shadow:
-        0 0 8px rgba(255, 107, 122, 0.2);
+    text-shadow: 0 0 8px rgb(255 107 122 / 20%);
 }
-
 
 /* =========================
    Прапорець
@@ -323,14 +225,9 @@ body {
 
 .cell.flag {
     background: #3a345c;
-
     font-size: 1.3rem;
-
-    box-shadow:
-        inset 0 2px 0 rgba(255, 255, 255, 0.07),
-        0 3px 5px rgba(0, 0, 0, 0.25);
+    box-shadow: inset 0 2px 0 rgb(255 255 255 / 7%), 0 3px 5px rgb(0 0 0 / 25%);
 }
-
 
 /* =========================
    Міни
@@ -340,18 +237,13 @@ body {
     font-size: 1.3rem;
 }
 
-
 /* Міна, на яку натиснув користувач */
 
 .cell.mine.clicked {
     background: var(--mine-red);
-
-    box-shadow:
-        inset 0 3px 6px rgba(70, 0, 15, 0.45);
-
+    box-shadow: inset 0 3px 6px rgb(70 0 15 / 45%);
     animation: shake 0.3s ease-in-out;
 }
-
 
 /* =========================
    Анімація вибуху
@@ -361,59 +253,45 @@ body {
     0% {
         transform: translateX(0);
     }
-
     25% {
         transform: translateX(-3px);
     }
-
     50% {
         transform: translateX(3px);
     }
-
     75% {
         transform: translateX(-3px);
     }
-
     100% {
         transform: translateX(0);
     }
 }
 
-
 /* =========================
    Адаптивність
    ========================= */
 
-@media (max-width: 400px) {
-
+@media (width <= 400px) {
     body {
         padding: 14px;
     }
-
     .game-container {
         padding: 14px;
         border-radius: 20px;
     }
-
     .game-header {
         padding: 8px;
     }
-
     .counter {
         min-width: 68px;
-
         padding: 7px 8px;
-
         font-size: 0.82rem;
     }
-
     .reset-btn {
         width: 40px;
         height: 40px;
-
         font-size: 1.35rem;
     }
-
     .game-board {
         gap: 4px;
         padding: 7px;

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,6 @@
       "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -118,7 +117,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -167,7 +165,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -518,7 +515,6 @@
       "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -780,7 +776,6 @@
       "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mdn-data": "2.27.1",
         "source-map-js": "^1.2.1"
@@ -887,7 +882,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -1836,7 +1830,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
@@ -1886,7 +1879,6 @@
       "integrity": "sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"


### PR DESCRIPTION
## What was done
Додано HTML-структуру та CSS-стилізацію для візуальної частини гри Minesweeper. 
Реалізовано хедер (таймер, лічильник прапорців, кнопка старту) та ігрове поле з усіма необхідними станами клітинок (закрита, відкрита, цифри, прапорець, міна).

<!-- Briefly describe what this PR implements or changes -->

## Screenshots
<img width="560" height="543" alt="image" src="https://github.com/user-attachments/assets/6727e1eb-8aeb-48f4-a48d-d50fa2045771" />


<!-- Add screenshots of your Minesweeper game here -->

## Checklist

- [x] PR title follows the format `lab{number}: Short description` (e.g. `lab1: Add layout`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

* Added a Ukrainian-language Minesweeper game page.
* Added a 4×4 board with numbered, empty, flagged, closed, and mined cells.
* Added flag and timer counters, plus a reset button.
* Added visual distinction between correctly mined flags and incorrectly flagged safe cells.
* Added accessibility metadata and responsive support for smaller screens.
* Added a dark-themed layout with colored numbers and explosion animation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->